### PR TITLE
Add 'set' option to search byName

### DIFF
--- a/src/Scry.ts
+++ b/src/Scry.ts
@@ -143,9 +143,10 @@ export class MagicEmitter<T> extends EventEmitter {
 }
 
 export module Cards {
-	export async function byName (name: string, fuzzy = false) {
+	export async function byName (name: string, fuzzy = false, set?: string) {
 		return queryApi<Card>("cards/named", {
 			[fuzzy ? "fuzzy" : "exact"]: name,
+			"set": set,
 		});
 	}
 

--- a/src/tests/Main.ts
+++ b/src/tests/Main.ts
@@ -32,6 +32,12 @@ describe("Scry", function () {
 				expect(card.name).eq("Blood Scrivener");
 				expect(Scry.error()).eq(undefined);
 			});
+
+			it("set", async () => {
+				const card = await Scry.Cards.byName("Warhammer", true, "MRD");
+				expect(card.set).eq("mrd");
+				expect(Scry.error()).eq(undefined);
+			});
 		});
 
 		it("by set", async () => {


### PR DESCRIPTION
In order to get a particular printing of a card out of the cards/named end point, you need to specify the set option, otherwise Scryfall will choose for you. More information can be found at: https://scryfall.com/docs/api/cards/named